### PR TITLE
Add TLS support via --tls flag for HTTPS endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The nagios check has the following options
 
 -d, --disabled        The monitoring check is disabled
 
+  --tls               Enable TLS/SSL for the connection to solr
+
 ```
 
 # Available Checks


### PR DESCRIPTION
Add TLS support via a `--tls` flag for endpoints that are https enabled. This also cleans up some whitespace.